### PR TITLE
Add dependency on micro_ros_agent package so it gets built first

### DIFF
--- a/ap_ci_tests/package.xml
+++ b/ap_ci_tests/package.xml
@@ -11,6 +11,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>micro_ros_agent</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This adds a missing dependency declaration. Without it you get this: 
```bash
ryan@ryan-B650:~/Development/ardu_ws$ ros2 launch ap_ci_tests ci_test.launch.py 
[INFO] [launch]: All log files can be found below /home/ryan/.ros/log/2023-03-12-18-07-35-394075-ryan-B650-115909
[INFO] [launch]: Default logging verbosity is set to INFO
/Users/rhys/Code/ros2/xrce-dds/ardupilot_ros2_ws/src/ardupilot
/Users/rhys/Code/ros2/xrce-dds/ardupilot_ros2_ws/src/ardupilot/libraries/AP_DDS/dds_xrce_profile.xml
[INFO] [ttyROS0 -1]: process started with pid [115910]
[INFO] [launch.user]: create_ports started
[ERROR] [launch]: Caught exception in launch (see debug for traceback): "package 'micro_ros_agent' not found, searching: ['/opt/ros/humble', '/home/ryan/Development/ardu_ws/install/ap_ci_tests']"
```